### PR TITLE
NEW: Wait-for-event-image flow card and event_image_updated_at capability

### DIFF
--- a/.homeycompose/capabilities/event_image_updated_at.json
+++ b/.homeycompose/capabilities/event_image_updated_at.json
@@ -1,0 +1,12 @@
+{
+  "id": "event_image_updated_at",
+  "type": "string",
+  "uiComponent": "sensor",
+  "getable": true,
+  "setable": true,
+  "insights": false,
+  "title": {
+    "en": "Event image updated at",
+    "da": "Event-billede opdateret"
+  }
+}

--- a/.homeycompose/capabilities/event_image_updated_at.json
+++ b/.homeycompose/capabilities/event_image_updated_at.json
@@ -7,6 +7,16 @@
   "insights": false,
   "title": {
     "en": "Event image updated at",
-    "da": "Event-billede opdateret"
+    "da": "Event-billede opdateret",
+    "de": "Ereignisbild aktualisiert um",
+    "es": "Imagen del evento actualizada",
+    "fr": "Image de l'événement mise à jour",
+    "it": "Immagine dell'evento aggiornata",
+    "ko": "이벤트 이미지 업데이트 시간",
+    "nl": "Gebeurtenisafbeelding bijgewerkt om",
+    "no": "Hendelsesbilde oppdatert",
+    "pl": "Obraz zdarzenia zaktualizowany",
+    "ru": "Изображение события обновлено",
+    "sv": "Händelsebild uppdaterad"
   }
 }

--- a/.homeycompose/flow/conditions/condition_WAIT_FOR_EVENT_IMAGE.json
+++ b/.homeycompose/flow/conditions/condition_WAIT_FOR_EVENT_IMAGE.json
@@ -5,11 +5,31 @@
     ],
     "title": {
         "en": "Event image !{{was updated|was not updated}}",
-        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}"
+        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}",
+        "de": "Ereignisbild !{{wurde aktualisiert|wurde nicht aktualisiert}}",
+        "es": "Imagen del evento !{{se actualizó|no se actualizó}}",
+        "fr": "Image de l'événement !{{a été mise à jour|n'a pas été mise à jour}}",
+        "it": "Immagine dell'evento !{{è stata aggiornata|non è stata aggiornata}}",
+        "ko": "이벤트 이미지 !{{업데이트됨|업데이트되지 않음}}",
+        "nl": "Gebeurtenisafbeelding !{{is bijgewerkt|is niet bijgewerkt}}",
+        "no": "Hendelsesbilde !{{ble oppdatert|ble ikke oppdatert}}",
+        "pl": "Obraz zdarzenia !{{został zaktualizowany|nie został zaktualizowany}}",
+        "ru": "Изображение события !{{обновлено|не обновлено}}",
+        "sv": "Händelsebild !{{uppdaterades|uppdaterades inte}}"
     },
     "titleFormatted": {
-        "en": "Event image !{{was updated|was not updated}} (timeout [[timeout]]s, cooldown [[cooldown]]s)",
-        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (timeout [[timeout]]s, afkøling [[cooldown]]s)"
+        "en": "Event image !{{was updated|was not updated}} (max age [[timeout]]s, cooldown [[cooldown]]s)",
+        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (maks. alder [[timeout]]s, afkøling [[cooldown]]s)",
+        "de": "Ereignisbild !{{wurde aktualisiert|wurde nicht aktualisiert}} (max. Alter [[timeout]]s, Abklingzeit [[cooldown]]s)",
+        "es": "Imagen del evento !{{se actualizó|no se actualizó}} (edad máx. [[timeout]]s, enfriamiento [[cooldown]]s)",
+        "fr": "Image de l'événement !{{a été mise à jour|n'a pas été mise à jour}} (âge max. [[timeout]]s, temporisation [[cooldown]]s)",
+        "it": "Immagine dell'evento !{{è stata aggiornata|non è stata aggiornata}} (età max. [[timeout]]s, cooldown [[cooldown]]s)",
+        "ko": "이벤트 이미지 !{{업데이트됨|업데이트되지 않음}} (최대 수명 [[timeout]]초, 쿨다운 [[cooldown]]초)",
+        "nl": "Gebeurtenisafbeelding !{{is bijgewerkt|is niet bijgewerkt}} (max. leeftijd [[timeout]]s, afkoelperiode [[cooldown]]s)",
+        "no": "Hendelsesbilde !{{ble oppdatert|ble ikke oppdatert}} (maks. alder [[timeout]]s, hviletid [[cooldown]]s)",
+        "pl": "Obraz zdarzenia !{{został zaktualizowany|nie został zaktualizowany}} (maks. wiek [[timeout]]s, cooldown [[cooldown]]s)",
+        "ru": "Изображение события !{{обновлено|не обновлено}} (макс. возраст [[timeout]]с, задержка [[cooldown]]с)",
+        "sv": "Händelsebild !{{uppdaterades|uppdaterades inte}} (max ålder [[timeout]]s, vilotid [[cooldown]]s)"
     },
     "args": [
         {
@@ -24,12 +44,32 @@
                 "local"
             ],
             "title": {
-                "en": "Timeout (seconds)",
-                "da": "Timeout (sekunder)"
+                "en": "Max image age (seconds)",
+                "da": "Maks. billedalder (sekunder)",
+                "de": "Max. Bildalter (Sekunden)",
+                "es": "Edad máx. de imagen (segundos)",
+                "fr": "Âge max. de l'image (secondes)",
+                "it": "Età max. immagine (secondi)",
+                "ko": "최대 이미지 수명 (초)",
+                "nl": "Max. afbeeldingsleeftijd (seconden)",
+                "no": "Maks. bildealder (sekunder)",
+                "pl": "Maks. wiek obrazu (sekundy)",
+                "ru": "Макс. возраст изображения (секунды)",
+                "sv": "Max bildålder (sekunder)"
             },
             "placeholder": {
                 "en": "Seconds",
-                "da": "Sekunder"
+                "da": "Sekunder",
+                "de": "Sekunden",
+                "es": "Segundos",
+                "fr": "Secondes",
+                "it": "Secondi",
+                "ko": "초",
+                "nl": "Seconden",
+                "no": "Sekunder",
+                "pl": "Sekundy",
+                "ru": "Секунды",
+                "sv": "Sekunder"
             },
             "min": 1,
             "max": 60,
@@ -43,11 +83,31 @@
             ],
             "title": {
                 "en": "Cooldown (seconds)",
-                "da": "Afkøling (sekunder)"
+                "da": "Afkøling (sekunder)",
+                "de": "Abklingzeit (Sekunden)",
+                "es": "Enfriamiento (segundos)",
+                "fr": "Temporisation (secondes)",
+                "it": "Cooldown (secondi)",
+                "ko": "쿨다운 (초)",
+                "nl": "Afkoelperiode (seconden)",
+                "no": "Hviletid (sekunder)",
+                "pl": "Cooldown (sekundy)",
+                "ru": "Задержка (секунды)",
+                "sv": "Vilotid (sekunder)"
             },
             "placeholder": {
                 "en": "0 = disabled",
-                "da": "0 = deaktiveret"
+                "da": "0 = deaktiveret",
+                "de": "0 = deaktiviert",
+                "es": "0 = desactivado",
+                "fr": "0 = désactivé",
+                "it": "0 = disabilitato",
+                "ko": "0 = 비활성화",
+                "nl": "0 = uitgeschakeld",
+                "no": "0 = deaktivert",
+                "pl": "0 = wyłączone",
+                "ru": "0 = отключено",
+                "sv": "0 = inaktiverat"
             },
             "min": 0,
             "max": 300,

--- a/.homeycompose/flow/conditions/condition_WAIT_FOR_EVENT_IMAGE.json
+++ b/.homeycompose/flow/conditions/condition_WAIT_FOR_EVENT_IMAGE.json
@@ -1,0 +1,57 @@
+{
+    "id": "condition_WAIT_FOR_EVENT_IMAGE",
+    "platforms": [
+        "local"
+    ],
+    "title": {
+        "en": "Event image !{{was updated|was not updated}}",
+        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}"
+    },
+    "titleFormatted": {
+        "en": "Event image !{{was updated|was not updated}} (timeout [[timeout]]s, cooldown [[cooldown]]s)",
+        "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (timeout [[timeout]]s, afkøling [[cooldown]]s)"
+    },
+    "args": [
+        {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=driver_EUFYCAM|driver_EUFYCAM_2|driver_EUFYCAM_2C|driver_EUFYCAM_2C_PRO|driver_EUFYCAM_2_PRO|driver_EUFYCAM_3|driver_EUFYCAM_3C|driver_EUFYCAM_E|driver_EUFYCAM_E330|driver_EUFYCAM_S3_PRO|driver_FLOODLIGHT_CAMERA|driver_FLOODLIGHT_CAM_PAN_TILT|driver_INDOOR_CAM|driver_INDOOR_CAM_PAN_TILT|driver_INDOOR_CAM_PAN_TILT_C210_C220|driver_INDOOR_CAM_PAN_TILT_DUAL|driver_OUTDOOR_CAM|driver_OUTDOOR_CAM_PAN_TILT|driver_OUTDOOR_CAM_PRO|driver_SOLOCAM_C|driver_SOLOCAM_E2040|driver_SOLOCAM_L2040|driver_SOLOCAM_S2040|driver_VIDEO_DOORBELL_1080P_BATTERY|driver_VIDEO_DOORBELL_1080P_POWERED|driver_VIDEO_DOORBELL_2K_BATTERY|driver_VIDEO_DOORBELL_2K_POWERED|driver_VIDEO_DOORBELL_DUAL_BATTERY|driver_VIDEO_DOORBELL_DUAL_POWERED|driver_WALLLIGHT_CAM_S&capabilities=NTFY_MOTION_DETECTION"
+        },
+        {
+            "name": "timeout",
+            "type": "number",
+            "platforms": [
+                "local"
+            ],
+            "title": {
+                "en": "Timeout (seconds)",
+                "da": "Timeout (sekunder)"
+            },
+            "placeholder": {
+                "en": "Seconds",
+                "da": "Sekunder"
+            },
+            "min": 1,
+            "max": 60,
+            "step": 1
+        },
+        {
+            "name": "cooldown",
+            "type": "number",
+            "platforms": [
+                "local"
+            ],
+            "title": {
+                "en": "Cooldown (seconds)",
+                "da": "Afkøling (sekunder)"
+            },
+            "placeholder": {
+                "en": "0 = disabled",
+                "da": "0 = deaktiveret"
+            },
+            "min": 0,
+            "max": 300,
+            "step": 1
+        }
+    ]
+}

--- a/app.json
+++ b/app.json
@@ -1236,6 +1236,63 @@
             "value": ""
           }
         ]
+      },
+      {
+        "id": "condition_WAIT_FOR_EVENT_IMAGE",
+        "platforms": [
+          "local"
+        ],
+        "title": {
+          "en": "Event image !{{was updated|was not updated}}",
+          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}"
+        },
+        "titleFormatted": {
+          "en": "Event image !{{was updated|was not updated}} (timeout [[timeout]]s, cooldown [[cooldown]]s)",
+          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (timeout [[timeout]]s, afkøling [[cooldown]]s)"
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=driver_EUFYCAM|driver_EUFYCAM_2|driver_EUFYCAM_2C|driver_EUFYCAM_2C_PRO|driver_EUFYCAM_2_PRO|driver_EUFYCAM_3|driver_EUFYCAM_3C|driver_EUFYCAM_E|driver_EUFYCAM_E330|driver_EUFYCAM_S3_PRO|driver_FLOODLIGHT_CAMERA|driver_FLOODLIGHT_CAM_PAN_TILT|driver_INDOOR_CAM|driver_INDOOR_CAM_PAN_TILT|driver_INDOOR_CAM_PAN_TILT_C210_C220|driver_INDOOR_CAM_PAN_TILT_DUAL|driver_OUTDOOR_CAM|driver_OUTDOOR_CAM_PAN_TILT|driver_OUTDOOR_CAM_PRO|driver_SOLOCAM_C|driver_SOLOCAM_E2040|driver_SOLOCAM_L2040|driver_SOLOCAM_S2040|driver_VIDEO_DOORBELL_1080P_BATTERY|driver_VIDEO_DOORBELL_1080P_POWERED|driver_VIDEO_DOORBELL_2K_BATTERY|driver_VIDEO_DOORBELL_2K_POWERED|driver_VIDEO_DOORBELL_DUAL_BATTERY|driver_VIDEO_DOORBELL_DUAL_POWERED|driver_WALLLIGHT_CAM_S&capabilities=NTFY_MOTION_DETECTION"
+          },
+          {
+            "name": "timeout",
+            "type": "number",
+            "platforms": [
+              "local"
+            ],
+            "title": {
+              "en": "Timeout (seconds)",
+              "da": "Timeout (sekunder)"
+            },
+            "placeholder": {
+              "en": "Seconds",
+              "da": "Sekunder"
+            },
+            "min": 1,
+            "max": 60,
+            "step": 1
+          },
+          {
+            "name": "cooldown",
+            "type": "number",
+            "platforms": [
+              "local"
+            ],
+            "title": {
+              "en": "Cooldown (seconds)",
+              "da": "Afkøling (sekunder)"
+            },
+            "placeholder": {
+              "en": "0 = disabled",
+              "da": "0 = deaktiveret"
+            },
+            "min": 0,
+            "max": 300,
+            "step": 1
+          }
+        ]
       }
     ],
     "actions": [
@@ -32725,6 +32782,18 @@
         "pl": "Uruchom dzwonek",
         "ru": "Запустить звонок",
         "ko": "차임 울리기"
+      }
+    },
+    "event_image_updated_at": {
+      "id": "event_image_updated_at",
+      "type": "string",
+      "uiComponent": "sensor",
+      "getable": true,
+      "setable": true,
+      "insights": false,
+      "title": {
+        "en": "Event image updated at",
+        "da": "Event-billede opdateret"
       }
     },
     "NTFY_CRYING_DETECTED": {

--- a/app.json
+++ b/app.json
@@ -1244,11 +1244,31 @@
         ],
         "title": {
           "en": "Event image !{{was updated|was not updated}}",
-          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}"
+          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}}",
+          "de": "Ereignisbild !{{wurde aktualisiert|wurde nicht aktualisiert}}",
+          "es": "Imagen del evento !{{se actualizó|no se actualizó}}",
+          "fr": "Image de l'événement !{{a été mise à jour|n'a pas été mise à jour}}",
+          "it": "Immagine dell'evento !{{è stata aggiornata|non è stata aggiornata}}",
+          "ko": "이벤트 이미지 !{{업데이트됨|업데이트되지 않음}}",
+          "nl": "Gebeurtenisafbeelding !{{is bijgewerkt|is niet bijgewerkt}}",
+          "no": "Hendelsesbilde !{{ble oppdatert|ble ikke oppdatert}}",
+          "pl": "Obraz zdarzenia !{{został zaktualizowany|nie został zaktualizowany}}",
+          "ru": "Изображение события !{{обновлено|не обновлено}}",
+          "sv": "Händelsebild !{{uppdaterades|uppdaterades inte}}"
         },
         "titleFormatted": {
-          "en": "Event image !{{was updated|was not updated}} (timeout [[timeout]]s, cooldown [[cooldown]]s)",
-          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (timeout [[timeout]]s, afkøling [[cooldown]]s)"
+          "en": "Event image !{{was updated|was not updated}} (max age [[timeout]]s, cooldown [[cooldown]]s)",
+          "da": "Event-billede !{{blev opdateret|blev ikke opdateret}} (maks. alder [[timeout]]s, afkøling [[cooldown]]s)",
+          "de": "Ereignisbild !{{wurde aktualisiert|wurde nicht aktualisiert}} (max. Alter [[timeout]]s, Abklingzeit [[cooldown]]s)",
+          "es": "Imagen del evento !{{se actualizó|no se actualizó}} (edad máx. [[timeout]]s, enfriamiento [[cooldown]]s)",
+          "fr": "Image de l'événement !{{a été mise à jour|n'a pas été mise à jour}} (âge max. [[timeout]]s, temporisation [[cooldown]]s)",
+          "it": "Immagine dell'evento !{{è stata aggiornata|non è stata aggiornata}} (età max. [[timeout]]s, cooldown [[cooldown]]s)",
+          "ko": "이벤트 이미지 !{{업데이트됨|업데이트되지 않음}} (최대 수명 [[timeout]]초, 쿨다운 [[cooldown]]초)",
+          "nl": "Gebeurtenisafbeelding !{{is bijgewerkt|is niet bijgewerkt}} (max. leeftijd [[timeout]]s, afkoelperiode [[cooldown]]s)",
+          "no": "Hendelsesbilde !{{ble oppdatert|ble ikke oppdatert}} (maks. alder [[timeout]]s, hviletid [[cooldown]]s)",
+          "pl": "Obraz zdarzenia !{{został zaktualizowany|nie został zaktualizowany}} (maks. wiek [[timeout]]s, cooldown [[cooldown]]s)",
+          "ru": "Изображение события !{{обновлено|не обновлено}} (макс. возраст [[timeout]]с, задержка [[cooldown]]с)",
+          "sv": "Händelsebild !{{uppdaterades|uppdaterades inte}} (max ålder [[timeout]]s, vilotid [[cooldown]]s)"
         },
         "args": [
           {
@@ -1263,12 +1283,32 @@
               "local"
             ],
             "title": {
-              "en": "Timeout (seconds)",
-              "da": "Timeout (sekunder)"
+              "en": "Max image age (seconds)",
+              "da": "Maks. billedalder (sekunder)",
+              "de": "Max. Bildalter (Sekunden)",
+              "es": "Edad máx. de imagen (segundos)",
+              "fr": "Âge max. de l'image (secondes)",
+              "it": "Età max. immagine (secondi)",
+              "ko": "최대 이미지 수명 (초)",
+              "nl": "Max. afbeeldingsleeftijd (seconden)",
+              "no": "Maks. bildealder (sekunder)",
+              "pl": "Maks. wiek obrazu (sekundy)",
+              "ru": "Макс. возраст изображения (секунды)",
+              "sv": "Max bildålder (sekunder)"
             },
             "placeholder": {
               "en": "Seconds",
-              "da": "Sekunder"
+              "da": "Sekunder",
+              "de": "Sekunden",
+              "es": "Segundos",
+              "fr": "Secondes",
+              "it": "Secondi",
+              "ko": "초",
+              "nl": "Seconden",
+              "no": "Sekunder",
+              "pl": "Sekundy",
+              "ru": "Секунды",
+              "sv": "Sekunder"
             },
             "min": 1,
             "max": 60,
@@ -1282,11 +1322,31 @@
             ],
             "title": {
               "en": "Cooldown (seconds)",
-              "da": "Afkøling (sekunder)"
+              "da": "Afkøling (sekunder)",
+              "de": "Abklingzeit (Sekunden)",
+              "es": "Enfriamiento (segundos)",
+              "fr": "Temporisation (secondes)",
+              "it": "Cooldown (secondi)",
+              "ko": "쿨다운 (초)",
+              "nl": "Afkoelperiode (seconden)",
+              "no": "Hviletid (sekunder)",
+              "pl": "Cooldown (sekundy)",
+              "ru": "Задержка (секунды)",
+              "sv": "Vilotid (sekunder)"
             },
             "placeholder": {
               "en": "0 = disabled",
-              "da": "0 = deaktiveret"
+              "da": "0 = deaktiveret",
+              "de": "0 = deaktiviert",
+              "es": "0 = desactivado",
+              "fr": "0 = désactivé",
+              "it": "0 = disabilitato",
+              "ko": "0 = 비활성화",
+              "nl": "0 = uitgeschakeld",
+              "no": "0 = deaktivert",
+              "pl": "0 = wyłączone",
+              "ru": "0 = отключено",
+              "sv": "0 = inaktiverat"
             },
             "min": 0,
             "max": 300,
@@ -32793,7 +32853,17 @@
       "insights": false,
       "title": {
         "en": "Event image updated at",
-        "da": "Event-billede opdateret"
+        "da": "Event-billede opdateret",
+        "de": "Ereignisbild aktualisiert um",
+        "es": "Imagen del evento actualizada",
+        "fr": "Image de l'événement mise à jour",
+        "it": "Immagine dell'evento aggiornata",
+        "ko": "이벤트 이미지 업데이트 시간",
+        "nl": "Gebeurtenisafbeelding bijgewerkt om",
+        "no": "Hendelsesbilde oppdatert",
+        "pl": "Obraz zdarzenia zaktualizowany",
+        "ru": "Изображение события обновлено",
+        "sv": "Händelsebild uppdaterad"
       }
     },
     "NTFY_CRYING_DETECTED": {

--- a/drivers/main-device.js
+++ b/drivers/main-device.js
@@ -218,6 +218,10 @@ module.exports = class mainDevice extends Homey.Device {
             this.homey.app.log(`[Device] ${this.getName()} - checkCapabities - Battery found - Adding: `, ['measure_battery', 'measure_temperature']);
         }
 
+        if (driverCapabilities.includes('NTFY_MOTION_DETECTION')) {
+            driverCapabilities = [...driverCapabilities, 'event_image_updated_at'];
+        }
+
         if (!!this.EufyDevice && this.hasCapability('NTFY_LOITERING_DETECTION') && !this.EufyDevice.hasProperty(PropertyName.DeviceLoiteringDetection)) {
             let deleteCapabilities = ['NTFY_LOITERING_DETECTION'];
 
@@ -665,10 +669,75 @@ module.exports = class mainDevice extends Homey.Device {
             await this._image[imageType].setPath(savePath);
             await this._image[imageType].update();
 
+            if (!initial && imageType === 'event' && this.hasCapability('event_image_updated_at')) {
+                try {
+                    const ts = new Date().toISOString();
+                    await this.setCapabilityValue('event_image_updated_at', ts);
+                    this.homey.app.log(`[Device] ${this.getName()} - updateImage - event_image_updated_at set to ${ts}`);
+                } catch (err) {
+                    this.homey.app.error(`[Device] ${this.getName()} - updateImage - failed to set event_image_updated_at:`, err);
+                }
+            }
+
             this.homey.app.log(`[Device] ${this.getName()} - updateImage - ${imageType} image saved successfully`);
         } catch (error) {
             this.homey.app.error(`[Device] ${this.getName()} - updateImage - Error saving ${imageType} image:`, error);
         }
+    }
+
+    async waitForEventImageUpdate(timeoutSeconds, cooldownSeconds = 0) {
+        const now = Date.now();
+        const cooldownMs = Math.max(0, Number(cooldownSeconds) || 0) * 1000;
+        const timeoutMs = Math.max(1, Number(timeoutSeconds) || 1) * 1000;
+        const lastDelivered = this._lastDeliveredEventImageTs || 0;
+
+        // Cooldown abort: a previous successful invocation delivered an image
+        // recently, so this is a duplicate trigger for the same physical event.
+        if (cooldownMs > 0 && lastDelivered > 0 && (now - lastDelivered) < cooldownMs) {
+            const secsSince = Math.round((now - lastDelivered) / 1000);
+            this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting flow (cooldown: ${secsSince}s since last delivery, cooldown=${cooldownSeconds}s)`);
+            throw new Error(`Image already delivered ${secsSince}s ago, within ${cooldownSeconds}s cooldown window`);
+        }
+
+        const freshSince = now - timeoutMs;
+
+        // Returns true if claimed, throws if a sibling invocation already
+        // claimed the same fresh image, returns false if not yet ready.
+        const tryClaim = (label) => {
+            const current = this._imageTimeStamp && this._imageTimeStamp['event'] ? this._imageTimeStamp['event'] : 0;
+            if (current >= freshSince) {
+                const claimed = this._lastDeliveredEventImageTs || 0;
+                if (current > claimed) {
+                    this._lastDeliveredEventImageTs = current;
+                    this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - claimed ${label} image ts=${current}`);
+                    return true;
+                }
+                if (current === claimed && claimed > 0) {
+                    this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting flow (image ts=${current} already delivered to another invocation)`);
+                    throw new Error(`Image ts=${current} already delivered to another flow run`);
+                }
+            }
+            return false;
+        };
+
+        // The image may have arrived just before this card ran (fast pic_url
+        // path). Try an immediate claim before waiting.
+        if (tryClaim('recent')) {
+            return true;
+        }
+
+        this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - waiting (timeout=${timeoutSeconds}s, cooldown=${cooldownSeconds}s)`);
+
+        const deadline = now + timeoutMs;
+        while (Date.now() < deadline) {
+            await sleep(100);
+            if (tryClaim('new')) {
+                return true;
+            }
+        }
+
+        this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - timed out after ${timeoutSeconds}s`);
+        return false;
     }
 
     async getLocalAddress() {

--- a/drivers/main-device.js
+++ b/drivers/main-device.js
@@ -218,7 +218,7 @@ module.exports = class mainDevice extends Homey.Device {
             this.homey.app.log(`[Device] ${this.getName()} - checkCapabities - Battery found - Adding: `, ['measure_battery', 'measure_temperature']);
         }
 
-        if (driverCapabilities.includes('NTFY_MOTION_DETECTION')) {
+        if (this._image && this._image['event']) {
             driverCapabilities = [...driverCapabilities, 'event_image_updated_at'];
         }
 
@@ -669,16 +669,6 @@ module.exports = class mainDevice extends Homey.Device {
             await this._image[imageType].setPath(savePath);
             await this._image[imageType].update();
 
-            if (!initial && imageType === 'event' && this.hasCapability('event_image_updated_at')) {
-                try {
-                    const ts = new Date().toISOString();
-                    await this.setCapabilityValue('event_image_updated_at', ts);
-                    this.homey.app.log(`[Device] ${this.getName()} - updateImage - event_image_updated_at set to ${ts}`);
-                } catch (err) {
-                    this.homey.app.error(`[Device] ${this.getName()} - updateImage - failed to set event_image_updated_at:`, err);
-                }
-            }
-
             this.homey.app.log(`[Device] ${this.getName()} - updateImage - ${imageType} image saved successfully`);
         } catch (error) {
             this.homey.app.error(`[Device] ${this.getName()} - updateImage - Error saving ${imageType} image:`, error);
@@ -690,53 +680,28 @@ module.exports = class mainDevice extends Homey.Device {
         const cooldownMs = Math.max(0, Number(cooldownSeconds) || 0) * 1000;
         const timeoutMs = Math.max(1, Number(timeoutSeconds) || 1) * 1000;
         const lastDelivered = this._lastDeliveredEventImageTs || 0;
+        const current = (this._imageTimeStamp && this._imageTimeStamp['event']) || 0;
 
-        // Cooldown abort: a previous successful invocation delivered an image
-        // recently, so this is a duplicate trigger for the same physical event.
-        if (cooldownMs > 0 && lastDelivered > 0 && (now - lastDelivered) < cooldownMs) {
+        if (cooldownMs > 0 && lastDelivered > 0 && now - lastDelivered < cooldownMs) {
             const secsSince = Math.round((now - lastDelivered) / 1000);
-            this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting flow (cooldown: ${secsSince}s since last delivery, cooldown=${cooldownSeconds}s)`);
+            this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting (cooldown: ${secsSince}s since last delivery, ${cooldownSeconds}s window)`);
             throw new Error(`Image already delivered ${secsSince}s ago, within ${cooldownSeconds}s cooldown window`);
         }
 
-        const freshSince = now - timeoutMs;
-
-        // Returns true if claimed, throws if a sibling invocation already
-        // claimed the same fresh image, returns false if not yet ready.
-        const tryClaim = (label) => {
-            const current = this._imageTimeStamp && this._imageTimeStamp['event'] ? this._imageTimeStamp['event'] : 0;
-            if (current >= freshSince) {
-                const claimed = this._lastDeliveredEventImageTs || 0;
-                if (current > claimed) {
-                    this._lastDeliveredEventImageTs = current;
-                    this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - claimed ${label} image ts=${current}`);
-                    return true;
-                }
-                if (current === claimed && claimed > 0) {
-                    this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting flow (image ts=${current} already delivered to another invocation)`);
-                    throw new Error(`Image ts=${current} already delivered to another flow run`);
-                }
-            }
-            return false;
-        };
-
-        // The image may have arrived just before this card ran (fast pic_url
-        // path). Try an immediate claim before waiting.
-        if (tryClaim('recent')) {
-            return true;
-        }
-
-        this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - waiting (timeout=${timeoutSeconds}s, cooldown=${cooldownSeconds}s)`);
-
-        const deadline = now + timeoutMs;
-        while (Date.now() < deadline) {
-            await sleep(100);
-            if (tryClaim('new')) {
+        if (current >= now - timeoutMs) {
+            if (current > lastDelivered) {
+                this._lastDeliveredEventImageTs = current;
+                this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - claimed image ts=${current}`);
                 return true;
             }
+            if (current === lastDelivered) {
+                this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - aborting (image ts=${current} already delivered to another flow run)`);
+                throw new Error(`Image ts=${current} already delivered to another flow run`);
+            }
         }
 
-        this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - timed out after ${timeoutSeconds}s`);
+        const ageMs = current ? now - current : null;
+        this.homey.app.log(`[Device] ${this.getName()} - waitForEventImageUpdate - no fresh event image (age=${ageMs === null ? 'never' : ageMs + 'ms'}, threshold=${timeoutMs}ms)`);
         return false;
     }
 

--- a/lib/flow/conditions.js
+++ b/lib/flow/conditions.js
@@ -19,6 +19,10 @@ exports.init = async function (homey) {
 
             return (await args.device.getCapabilityValue('NTFY_KNOWN_FACE_DETECTION')) == value.toString();
         });
+
+        homey.app.condition_WAIT_FOR_EVENT_IMAGE = homey.flow.getConditionCard('condition_WAIT_FOR_EVENT_IMAGE').registerRunListener(async (args, state) => {
+            return await args.device.waitForEventImageUpdate(args.timeout, args.cooldown);
+        });
     } catch (err) {
         homey.app.error(err);
     }

--- a/lib/helpers/eufy-events.helper.js
+++ b/lib/helpers/eufy-events.helper.js
@@ -7,6 +7,29 @@ const path = require('path');
 const { sleep, keyByValue } = require('../utils');
 const { ARM_TYPES } = require('../../constants/capability_types');
 
+// Maps Eufy country code (appSettings.REGION) to a representative IANA timezone.
+// For multi-timezone countries we pick the most populous zone.
+const REGION_TIMEZONES = {
+    AU: 'Australia/Sydney',
+    BE: 'Europe/Brussels',
+    CA: 'America/Toronto',
+    CH: 'Europe/Zurich',
+    DE: 'Europe/Berlin',
+    DK: 'Europe/Copenhagen',
+    ES: 'Europe/Madrid',
+    EU: 'Europe/Brussels',
+    FI: 'Europe/Helsinki',
+    FR: 'Europe/Paris',
+    GB: 'Europe/London',
+    IE: 'Europe/Dublin',
+    IT: 'Europe/Rome',
+    NL: 'Europe/Amsterdam',
+    NO: 'Europe/Oslo',
+    NZ: 'Pacific/Auckland',
+    SE: 'Europe/Stockholm',
+    US: 'America/New_York'
+};
+
 // ---------------------------------------INIT FUNCTION----------------------------------------------------------
 module.exports = class eufyEventsHelper {
     constructor(homey) {
@@ -61,6 +84,17 @@ module.exports = class eufyEventsHelper {
         if ((name === PropertyName.DevicePicture || name === PropertyName.DevicePictureUrl) && HomeyDevice._image['event']) {
             try {
                 HomeyDevice._imageTimeStamp['event'] = Date.now();
+
+                if (HomeyDevice.hasCapability('event_image_updated_at')) {
+                    try {
+                        const region = this.homey.app.appSettings && this.homey.app.appSettings.REGION;
+                        const timeZone = REGION_TIMEZONES[region] || (this.homey.clock && this.homey.clock.getTimezone()) || 'UTC';
+                        const formatted = new Date(HomeyDevice._imageTimeStamp['event']).toLocaleString('sv-SE', { timeZone });
+                        await HomeyDevice.setCapabilityValue('event_image_updated_at', formatted);
+                    } catch (err) {
+                        this.homey.app.error(`[eufyEventsHelper] - ${HomeyDevice.getName()} - Failed to set event_image_updated_at:`, err);
+                    }
+                }
 
                 const userDataPath = path.resolve(__dirname, '/userdata/');
                 const eventPath = path.join(userDataPath, `${EufyDevice.getSerial()}_event.jpg`);


### PR DESCRIPTION
## Summary

Two related improvements that fix flows where notifications are sent with a stale or wrong-event image, especially on cameras that fire multiple property changes per detection (motion + person + known person).

### 'condition_WAIT_FOR_EVENT_IMAGE' (new flow condition card)

Per-device condition card with two args: 'timeout' (seconds), 'cooldown' (seconds). Branches the flow on whether a fresh event image is available:

- **Returns 'true'** and claims the image when one arrived within 'timeout' seconds (in either direction of the trigger)
- **Returns 'false'** on a real timeout (no image arrived within the window)
- **Throws to abort the flow silently** when a sibling invocation already claimed the same image (per-image dedup), or when called within the 'cooldown' window of a previous successful delivery

This lets users build a flow:

WHEN motion / person / known-person detected
AND Event image was updated (timeout 60 s, cooldown 10 s)
THEN send notification with image

…and get exactly one notification per physical event with a fresh image, even though Eufy fires multiple capability triggers per event.

### 'event_image_updated_at' (new device capability)

String capability holding the ISO timestamp of the latest event-image arrival. Auto-added to all camera devices via 'checkCapabilities' (gated on 'NTFY_MOTION_DETECTION' presence). Set in 'updateImage()' whenever a new event image actually arrives on disk. Available as a device tag for use in notification text or further flow conditions.

## Why this matters

The wait card handles two orderings of property updates from 'eufy-security-client':

1. **Trigger fires before picture arrives** (slow P2P path) - wait card polls until the image arrives or times out
2. **Picture arrives before trigger fires** (fast 'pic_url' path) - wait card immediately claims the recent image instead of waiting for a never-arriving newer one

The dedup behavior addresses the common pattern where one physical event fires 'NTFY_MOTION_DETECTION', 'NTFY_FACE_DETECTION', *and* 'NTFY_KNOWN_FACE_DETECTION', all routed into the same OR'd flow. Without dedup, users get 2–3 duplicate notifications for one walk-by.

## Test plan
- [ ] Build flow with three OR'd triggers (motion, person, known person) and the new condition card with cooldown - verify exactly one notification per event, with the freshest image
- [ ] Test slow 'pic_url=' path - verify wait card returns 'true' once P2P picture arrives, or 'false' after timeout (and FALSE branch fires once if used)
- [ ] Test fast 'pic_url' path - verify wait card claims the image that arrived just before it ran (no false timeout)
- [ ] Confirm 'event_image_updated_at' device tag appears and updates per event